### PR TITLE
Fix: Py3k waveform of strings put()

### DIFF
--- a/epics/ca.py
+++ b/epics/ca.py
@@ -1302,7 +1302,7 @@ def put(chid, value, wait=False, timeout=30, callback=None,
             data[0].value = value
         else:
             for elem in range(min(count, len(value))):
-                data[elem].value = value[elem]
+                data[elem].value = ascii_string(value[elem])
     elif nativecount == 1:
         if ftype == dbr.CHAR:
             if is_string_or_bytes(value):

--- a/tests/ca_unittest.py
+++ b/tests/ca_unittest.py
@@ -7,6 +7,7 @@ import time
 import unittest
 import numpy
 import ctypes
+from contextlib import contextmanager
 from epics import ca, dbr, caput
 
 import pvnames
@@ -38,11 +39,14 @@ def onChanges(pvname=None, value=None, **kws):
     global CHANGE_DAT
     CHANGE_DAT[pvname] = value
 
-def pause_updating():
-    caput(pvnames.pause_pv, 1)
-
-def resume_updating():
-    caput(pvnames.pause_pv, 0)
+@contextmanager
+def no_simulator_updates():
+    '''Context manager which pauses and resumes simulator PV updating'''
+    try:
+        caput(pvnames.pause_pv, 1)
+        yield
+    finally:
+        caput(pvnames.pause_pv, 0)
 
 class CA_BasicTests(unittest.TestCase):
 
@@ -65,7 +69,7 @@ class CA_BasicTests(unittest.TestCase):
         except ca.ChannelAccessException:
             out = True
         assert(out)
-        
+
     def testA_CreateChid_CheckTypeCount(self):
         write('Simple Test: create chid, check count, type, host, and access')
         chid = ca.create_channel(pvnames.double_pv)
@@ -304,90 +308,88 @@ class CA_BasicTests(unittest.TestCase):
         write( 'CA test Values (compare 5 values with caget)')
         os.system('rm ./caget.tst')
         vals = {}
-        pause_updating()
-        for pvn in (pvnames.str_pv,  pvnames.int_pv,
-                    pvnames.float_pv, pvnames.enum_pv,
-                    pvnames.long_pv):
-            os.system('caget  -n -f5 %s >> ./caget.tst' % pvn)
-            chid = ca.create_channel(pvn)
-            ca.connect_channel(chid)
-            vals[pvn] = ca.get(chid)
-        rlines = open('./caget.tst', 'r').readlines()
-        for line in rlines:
-            pvn, sval = [i.strip() for i in line[:-1].split(' ', 1)]
-            tval = str(vals[pvn])
-            if pvn in (pvnames.float_pv,pvnames.double_pv): # use float precision!
-                tval = "%.5f" % vals[pvn]
-            self.assertEqual(tval, sval)
-        resume_updating()
+        with no_simulator_updates():
+            for pvn in (pvnames.str_pv,  pvnames.int_pv,
+                        pvnames.float_pv, pvnames.enum_pv,
+                        pvnames.long_pv):
+                os.system('caget  -n -f5 %s >> ./caget.tst' % pvn)
+                chid = ca.create_channel(pvn)
+                ca.connect_channel(chid)
+                vals[pvn] = ca.get(chid)
+            rlines = open('./caget.tst', 'r').readlines()
+            for line in rlines:
+                pvn, sval = [i.strip() for i in line[:-1].split(' ', 1)]
+                tval = str(vals[pvn])
+                if pvn in (pvnames.float_pv,pvnames.double_pv):
+                    # use float precision!
+                    tval = "%.5f" % vals[pvn]
+                self.assertEqual(tval, sval)
 
     def test_type_converions_1(self):
         write("CA type conversions scalars")
         pvlist = (pvnames.str_pv, pvnames.int_pv, pvnames.float_pv,
                   pvnames.enum_pv,  pvnames.long_pv,  pvnames.double_pv2)
         chids = []
-        pause_updating()
-        for name in pvlist:
-            chid = ca.create_channel(name)
-            ca.connect_channel(chid)
-            chids.append((chid, name))
-            ca.poll(evt=0.025, iot=5.0)
-        ca.poll(evt=0.05, iot=10.0)
+        with no_simulator_updates():
+            for name in pvlist:
+                chid = ca.create_channel(name)
+                ca.connect_channel(chid)
+                chids.append((chid, name))
+                ca.poll(evt=0.025, iot=5.0)
+            ca.poll(evt=0.05, iot=10.0)
 
-        values = {}
-        for chid, name in chids:
-            values[name] = ca.get(chid, as_string=True)
+            values = {}
+            for chid, name in chids:
+                values[name] = ca.get(chid, as_string=True)
 
-        for promotion in ('ctrl', 'time'):
-            for chid, pvname in chids:
-                write('=== %s  chid=%s as %s' % (ca.name(chid),
-                                                   repr(chid), promotion))
-                time.sleep(0.01)
-                if promotion == 'ctrl':
-                    ntype = ca.promote_type(chid, use_ctrl=True)
-                else:
-                    ntype = ca.promote_type(chid, use_time=True)
+            for promotion in ('ctrl', 'time'):
+                for chid, pvname in chids:
+                    write('=== %s  chid=%s as %s' % (ca.name(chid), repr(chid),
+                                                     promotion))
+                    time.sleep(0.01)
+                    if promotion == 'ctrl':
+                        ntype = ca.promote_type(chid, use_ctrl=True)
+                    else:
+                        ntype = ca.promote_type(chid, use_time=True)
 
-                val  = ca.get(chid, ftype=ntype)
-                cval = ca.get(chid, as_string=True)
-                if ca.element_count(chid) > 1:
-                    val = val[:12]
-                self.assertEqual(cval, values[pvname])
-        resume_updating()
+                    val  = ca.get(chid, ftype=ntype)
+                    cval = ca.get(chid, as_string=True)
+                    if ca.element_count(chid) > 1:
+                        val = val[:12]
+                    self.assertEqual(cval, values[pvname])
 
     def test_type_converions_2(self):
         write("CA type conversions arrays")
         pvlist = (pvnames.char_arr_pv,
                   pvnames.long_arr_pv,
                   pvnames.double_arr_pv)
-        pause_updating()
-        chids = []
-        for name in pvlist:
-            chid = ca.create_channel(name)
-            ca.connect_channel(chid)
-            chids.append((chid, name))
-            ca.poll(evt=0.025, iot=5.0)
-        ca.poll(evt=0.05, iot=10.0)
+        with no_simulator_updates():
+            chids = []
+            for name in pvlist:
+                chid = ca.create_channel(name)
+                ca.connect_channel(chid)
+                chids.append((chid, name))
+                ca.poll(evt=0.025, iot=5.0)
+            ca.poll(evt=0.05, iot=10.0)
 
-        values = {}
-        for chid, name in chids:
-            values[name] = ca.get(chid)
-        for promotion in ('ctrl', 'time'):
-            for chid, pvname in chids:
-                write('=== %s  chid=%s as %s' % (ca.name(chid),
-                                                   repr(chid), promotion))
-                time.sleep(0.01)
-                if promotion == 'ctrl':
-                    ntype = ca.promote_type(chid, use_ctrl=True)
-                else:
-                    ntype = ca.promote_type(chid, use_time=True)
+            values = {}
+            for chid, name in chids:
+                values[name] = ca.get(chid)
+            for promotion in ('ctrl', 'time'):
+                for chid, pvname in chids:
+                    write('=== %s  chid=%s as %s' % (ca.name(chid), repr(chid),
+                                                     promotion))
+                    time.sleep(0.01)
+                    if promotion == 'ctrl':
+                        ntype = ca.promote_type(chid, use_ctrl=True)
+                    else:
+                        ntype = ca.promote_type(chid, use_time=True)
 
-                val  = ca.get(chid, ftype=ntype)
-                cval = ca.get(chid, as_string=True)
-                for a, b in zip(val, values[pvname]):
-                    self.assertEqual(a, b)
+                    val  = ca.get(chid, ftype=ntype)
+                    cval = ca.get(chid, as_string=True)
+                    for a, b in zip(val, values[pvname]):
+                        self.assertEqual(a, b)
 
-        resume_updating()
 
     def test_Array0(self):
         write('Array Test: get double array as numpy array, ctypes Array, and list')
@@ -428,7 +430,7 @@ class CA_BasicTests(unittest.TestCase):
         self.assertTrue(isinstance(out2, numpy.ndarray))
         self.assertEqual(len(out2), npts)
 
-        
+
     def test_xArray3(self):
         write('Array Test: get char array as string')
         chid = ca.create_channel(pvnames.char_arrays[0])

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -72,7 +72,7 @@ class PV_Tests(unittest.TestCase):
 
             self.failUnless(int(cval)== val)
 
-    def test_stringarray(self):
+    def test_get_string_waveform(self):
         write('String Array: \n')
         with no_simulator_updates():
             pv = PV(pvnames.string_arr_pv)
@@ -82,6 +82,15 @@ class PV_Tests(unittest.TestCase):
             self.failUnless(len(val[0]) > 1)
             self.assertIsInstance(val[1], str)
             self.failUnless(len(val[1]) > 1)
+
+    def test_put_string_waveform(self):
+        write('String Array: \n')
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            put_value = ['a', 'b', 'c']
+            pv.put(put_value)
+            get_value = pv.get(use_monitor=False, count=len(put_value))
+            numpy.testing.assert_array_equal(get_value, put_value)
 
     def test_putcomplete(self):
         write('Put with wait and put_complete (using real motor!) \n')

--- a/tests/pv_unittest.py
+++ b/tests/pv_unittest.py
@@ -6,6 +6,7 @@ import sys
 import time
 import unittest
 import numpy
+from contextlib import contextmanager
 from epics import PV, caput, caget, ca
 
 import pvnames
@@ -27,11 +28,15 @@ def onChanges(pvname=None, value=None, **kws):
     global CHANGE_DAT
     CHANGE_DAT[pvname] = value
 
-def pause_updating():
-    caput(pvnames.pause_pv, 1)
+@contextmanager
+def no_simulator_updates():
+    '''Context manager which pauses and resumes simulator PV updating'''
+    try:
+        caput(pvnames.pause_pv, 1)
+        yield
+    finally:
+        caput(pvnames.pause_pv, 0)
 
-def resume_updating():
-    caput(pvnames.pause_pv, 0)
 
 class PV_Tests(unittest.TestCase):
     def testA_CreatePV(self):
@@ -60,26 +65,23 @@ class PV_Tests(unittest.TestCase):
 
     def test_get1(self):
         write('Simple Test: test value and char_value on an integer\n')
-        pause_updating()
-        pv = PV(pvnames.int_pv)
-        val = pv.get()
-        cval = pv.get(as_string=True)
+        with no_simulator_updates():
+            pv = PV(pvnames.int_pv)
+            val = pv.get()
+            cval = pv.get(as_string=True)
 
-        self.failUnless(int(cval)== val)
-        resume_updating()
-
+            self.failUnless(int(cval)== val)
 
     def test_stringarray(self):
         write('String Array: \n')
-        pause_updating()
-        pv = PV(pvnames.string_arr_pv)
-        val = pv.get()
-        self.failUnless(len(val) > 10)
-        self.failUnless(isinstance(val[0], str))
-        self.failUnless(len(val[0]) > 1)
-        self.failUnless(isinstance(val[1], str))
-        self.failUnless(len(val[1]) > 1)
-        resume_updating()
+        with no_simulator_updates():
+            pv = PV(pvnames.string_arr_pv)
+            val = pv.get()
+            self.failUnless(len(val) > 10)
+            self.assertIsInstance(val[0], str)
+            self.failUnless(len(val[0]) > 1)
+            self.assertIsInstance(val[1], str)
+            self.failUnless(len(val[1]) > 1)
 
     def test_putcomplete(self):
         write('Put with wait and put_complete (using real motor!) \n')
@@ -105,7 +107,7 @@ class PV_Tests(unittest.TestCase):
         val = pv.get()
 
         t0 = time.time()
-        if  val < 5:
+        if val < 5:
             pv.put(val + 1.0, wait=True)
         else:
             pv.put(val - 1.0, wait=True)
@@ -243,34 +245,32 @@ class PV_Tests(unittest.TestCase):
         pvlist = (pvnames.char_arr_pv,
                   pvnames.long_arr_pv,
                   pvnames.double_arr_pv)
-        pause_updating()
-        chids = []
-        for name in pvlist:
-            chid = ca.create_channel(name)
-            ca.connect_channel(chid)
-            chids.append((chid, name))
-            ca.poll(evt=0.025, iot=5.0)
-        ca.poll(evt=0.05, iot=10.0)
+        with no_simulator_updates():
+            chids = []
+            for name in pvlist:
+                chid = ca.create_channel(name)
+                ca.connect_channel(chid)
+                chids.append((chid, name))
+                ca.poll(evt=0.025, iot=5.0)
+            ca.poll(evt=0.05, iot=10.0)
 
-        values = {}
-        for chid, name in chids:
-            values[name] = ca.get(chid)
-        for promotion in ('ctrl', 'time'):
-            for chid, pvname in chids:
-                write('=== %s  chid=%s as %s\n' % (ca.name(chid),
-                                                   repr(chid), promotion))
-                time.sleep(0.01)
-                if promotion == 'ctrl':
-                    ntype = ca.promote_type(chid, use_ctrl=True)
-                else:
-                    ntype = ca.promote_type(chid, use_time=True)
+            values = {}
+            for chid, name in chids:
+                values[name] = ca.get(chid)
+            for promotion in ('ctrl', 'time'):
+                for chid, pvname in chids:
+                    write('=== %s  chid=%s as %s\n' % (ca.name(chid),
+                                                       repr(chid), promotion))
+                    time.sleep(0.01)
+                    if promotion == 'ctrl':
+                        ntype = ca.promote_type(chid, use_ctrl=True)
+                    else:
+                        ntype = ca.promote_type(chid, use_time=True)
 
-                val  = ca.get(chid, ftype=ntype)
-                cval = ca.get(chid, as_string=True)
-                for a, b in zip(val, values[pvname]):
-                    self.assertEqual(a, b)
-
-        resume_updating()
+                    val  = ca.get(chid, ftype=ntype)
+                    cval = ca.get(chid, as_string=True)
+                    for a, b in zip(val, values[pvname]):
+                        self.assertEqual(a, b)
 
     def test_waveform_get_1elem(self):
         pv = PV(pvnames.double_arr_pv)


### PR DESCRIPTION
- Fixes py3k waveform of strings `put()`, added a unit test for it. It was just a missing a call to `ascii_string`. 
- Adds a context manager to pause simulator updating for the tests. I found that if one test failed it might affect the others, as simulator updating was never resumed
- All tests are passing now (minus the 'real motor' one which I don't have an IOC for - I added a skiptest for this in my other PR #49).
